### PR TITLE
add JWT authentication and tenant header support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,27 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+        <!-- JJWT Implementation -->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <!-- JJWT Jackson extensions (for JSON parsing) -->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
+
 
     <build>
         <plugins>

--- a/src/main/java/org/andi/librarymanagementbackend/config/AppConfig.java
+++ b/src/main/java/org/andi/librarymanagementbackend/config/AppConfig.java
@@ -1,0 +1,14 @@
+package org.andi.librarymanagementbackend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/org/andi/librarymanagementbackend/config/JwtAuthenticationFilter.java
+++ b/src/main/java/org/andi/librarymanagementbackend/config/JwtAuthenticationFilter.java
@@ -1,0 +1,51 @@
+package org.andi.librarymanagementbackend.config;
+
+import org.andi.librarymanagementbackend.service.impl.UserDetailsServiceImpl;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import io.jsonwebtoken.JwtException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsServiceImpl userDetailsService;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService) {
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain)
+            throws IOException, jakarta.servlet.ServletException {
+
+        String header = request.getHeader("Authorization");
+        if (StringUtils.hasText(header) && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+            try {
+                if (jwtUtil.validateToken(token)) {
+                    String email = jwtUtil.getUsernameFromToken(token);
+                    var userDetails = userDetailsService.loadUserByUsername(email);
+                    var auth = new UsernamePasswordAuthenticationToken(
+                            userDetails, null, userDetails.getAuthorities());
+                    auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(auth);
+                }
+            } catch (JwtException ex) {
+                // token invalid – mund ta log-osh ose t’i refuzosh
+                SecurityContextHolder.clearContext();
+            }
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/org/andi/librarymanagementbackend/config/JwtUtil.java
+++ b/src/main/java/org/andi/librarymanagementbackend/config/JwtUtil.java
@@ -1,0 +1,47 @@
+package org.andi.librarymanagementbackend.config;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    // Gjenero një Key HS512 të gjatë (512 bit) automatikisht
+    private final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS512);
+
+    // Sa zgjat token-i (një orë në këtë shembull)
+    private final int jwtExpirationMs = 3600_000;
+
+    public String generateToken(String username) {
+        return Jwts.builder()
+                .setSubject(username)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + jwtExpirationMs))
+                .signWith(key)
+                .compact();
+    }
+
+    public String getUsernameFromToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    public boolean validateToken(String authToken) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(authToken);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+}
+
+

--- a/src/main/java/org/andi/librarymanagementbackend/config/SecurityConfig.java
+++ b/src/main/java/org/andi/librarymanagementbackend/config/SecurityConfig.java
@@ -1,25 +1,66 @@
 package org.andi.librarymanagementbackend.config;
 
+import org.andi.librarymanagementbackend.service.impl.UserDetailsServiceImpl;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import static org.springframework.security.config.Customizer.withDefaults;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
-@EnableWebSecurity
+@EnableMethodSecurity // për @PreAuthorize në controller-at
 public class SecurityConfig {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsServiceImpl userDetailsService;
+
+    public SecurityConfig(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService) {
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        var jwtFilter = new JwtAuthenticationFilter(jwtUtil, userDetailsService);
+
         http
+                // 1) Hiq CSRF (pasi jemi stateless)
+                .csrf(csrf -> csrf.disable())
+
+                // 2) Bëj session stateless
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // 3) Ç’aktivo form-login dhe HTTP Basic
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+
+                // 4) Rregullat e aksesit
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
+                        .requestMatchers("/api/auth/**", "/swagger-ui/**", "/v3/api-docs/**")
+                        .permitAll()
+                        .anyRequest()
+                        .authenticated()
                 )
-                .csrf(csrf -> csrf.disable()); // kjo mënyrë nuk është deprecated
+
+                // 5) Shto JWTFilter përpara filter-it të Spring Security
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+
+                // 6) Vendos UserDetailsService
+                .userDetailsService(userDetailsService);
 
         return http.build();
     }
+
+    // Nëse të duhet AuthenticationManager për login manual, e deklaron kështu:
+    @Bean
+    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
+        return http.getSharedObject(AuthenticationManager.class);
+    }
 }
+
 
 

--- a/src/main/java/org/andi/librarymanagementbackend/controller/AuthController.java
+++ b/src/main/java/org/andi/librarymanagementbackend/controller/AuthController.java
@@ -1,0 +1,37 @@
+package org.andi.librarymanagementbackend.controller;
+
+import org.andi.librarymanagementbackend.dto.AuthResponseDto;
+import org.andi.librarymanagementbackend.dto.LoginRequestDto;
+import org.andi.librarymanagementbackend.dto.RegisterRequestDto;
+import org.andi.librarymanagementbackend.service.AuthService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@CrossOrigin(origins = "*")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+
+
+    @PostMapping("/register")
+    public ResponseEntity<AuthResponseDto> register(
+            @RequestHeader("X-Tenant-ID") String tenantId,
+            @RequestBody RegisterRequestDto dto) {
+        return ResponseEntity.ok(authService.register(dto));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponseDto> login(
+            @RequestHeader("X-Tenant-ID") String tenantId,
+            @RequestBody LoginRequestDto dto) {
+        return ResponseEntity.ok(authService.login(dto));
+    }
+}
+

--- a/src/main/java/org/andi/librarymanagementbackend/controller/AuthorController.java
+++ b/src/main/java/org/andi/librarymanagementbackend/controller/AuthorController.java
@@ -3,6 +3,7 @@ package org.andi.librarymanagementbackend.controller;
 import org.andi.librarymanagementbackend.dto.AuthorDto;
 import org.andi.librarymanagementbackend.service.AuthorService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -18,6 +19,7 @@ public class AuthorController {
         this.authorService = authorService;
     }
 
+    @PreAuthorize("isAuthenticated()")
     @GetMapping
     public ResponseEntity<List<AuthorDto>> getAllAuthors(
             @RequestHeader("X-Tenant-ID") String tenantId
@@ -25,6 +27,7 @@ public class AuthorController {
         return ResponseEntity.ok(authorService.getAllAuthors());
     }
 
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/{id}")
     public ResponseEntity<AuthorDto> getAuthorById(
             @RequestHeader("X-Tenant-ID") String tenantId,
@@ -33,6 +36,7 @@ public class AuthorController {
         return ResponseEntity.ok(authorService.getAuthorById(id));
     }
 
+    @PreAuthorize("hasAnyRole('LIBRARIAN','ADMIN')")
     @PostMapping
     public ResponseEntity<AuthorDto> createAuthor(
             @RequestHeader("X-Tenant-ID") String tenantId,
@@ -41,6 +45,7 @@ public class AuthorController {
         return ResponseEntity.ok(authorService.createAuthor(authorDto));
     }
 
+    @PreAuthorize("hasAnyRole('LIBRARIAN','ADMIN')")
     @PutMapping("/{id}")
     public ResponseEntity<AuthorDto> updateAuthor(
             @RequestHeader("X-Tenant-ID") String tenantId,
@@ -50,6 +55,7 @@ public class AuthorController {
         return ResponseEntity.ok(authorService.updateAuthor(id, authorDto));
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteAuthor(
             @RequestHeader("X-Tenant-ID") String tenantId,

--- a/src/main/java/org/andi/librarymanagementbackend/controller/BookController.java
+++ b/src/main/java/org/andi/librarymanagementbackend/controller/BookController.java
@@ -3,6 +3,7 @@ package org.andi.librarymanagementbackend.controller;
 import org.andi.librarymanagementbackend.dto.BookDto;
 import org.andi.librarymanagementbackend.service.BookService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,6 +20,7 @@ public class BookController {
     }
 
     // GET all books
+    @PreAuthorize("isAuthenticated()")
     @GetMapping
     public ResponseEntity<List<BookDto>> getAllBooks(
             @RequestHeader("X-Tenant-ID") String tenantId
@@ -28,6 +30,7 @@ public class BookController {
     }
 
     // GET book by ID
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/{id}")
     public ResponseEntity<BookDto> getBookById(
             @RequestHeader("X-Tenant-ID") String tenantId,
@@ -37,6 +40,7 @@ public class BookController {
     }
 
     // POST create a new book
+    @PreAuthorize("hasAnyRole('LIBRARIAN','ADMIN')")
     @PostMapping
     public ResponseEntity<BookDto> createBook(
             @RequestHeader("X-Tenant-ID") String tenantId,
@@ -47,6 +51,7 @@ public class BookController {
     }
 
     // PUT update a book
+    @PreAuthorize("hasAnyRole('LIBRARIAN','ADMIN')")
     @PutMapping("/{id}")
     public ResponseEntity<BookDto> updateBook(
             @RequestHeader("X-Tenant-ID") String tenantId,
@@ -58,6 +63,7 @@ public class BookController {
     }
 
     // DELETE a book
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteBook(
             @RequestHeader("X-Tenant-ID") String tenantId,

--- a/src/main/java/org/andi/librarymanagementbackend/controller/CategoryController.java
+++ b/src/main/java/org/andi/librarymanagementbackend/controller/CategoryController.java
@@ -3,6 +3,7 @@ package org.andi.librarymanagementbackend.controller;
 import org.andi.librarymanagementbackend.dto.CategoryDto;
 import org.andi.librarymanagementbackend.service.CategoryService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -17,22 +18,26 @@ public class CategoryController {
         this.service = service;
     }
 
+    @PreAuthorize("isAuthenticated()")
     @GetMapping
     public ResponseEntity<List<CategoryDto>> getAll() {
         return ResponseEntity.ok(service.getAll());
     }
 
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/{id}")
     public ResponseEntity<CategoryDto> getById(@PathVariable Long id) {
         return ResponseEntity.ok(service.getById(id));
     }
 
+    @PreAuthorize("hasAnyRole('LIBRARIAN','ADMIN')")
     @PostMapping
     public ResponseEntity<CategoryDto> create(@RequestBody CategoryDto dto) {
         CategoryDto created = service.create(dto);
         return ResponseEntity.status(201).body(created);
     }
 
+    @PreAuthorize("hasAnyRole('LIBRARIAN','ADMIN')")
     @PutMapping("/{id}")
     public ResponseEntity<CategoryDto> update(
             @PathVariable Long id,
@@ -40,7 +45,7 @@ public class CategoryController {
     ) {
         return ResponseEntity.ok(service.update(id, dto));
     }
-
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         service.delete(id);

--- a/src/main/java/org/andi/librarymanagementbackend/controller/PublisherController.java
+++ b/src/main/java/org/andi/librarymanagementbackend/controller/PublisherController.java
@@ -3,6 +3,7 @@ package org.andi.librarymanagementbackend.controller;
 import org.andi.librarymanagementbackend.dto.PublisherDto;
 import org.andi.librarymanagementbackend.service.PublisherService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -18,6 +19,7 @@ public class PublisherController {
         this.svc = svc;
     }
 
+    @PreAuthorize("isAuthenticated()")
     @GetMapping
     public ResponseEntity<List<PublisherDto>> getAllPublishers(
             @RequestHeader("X-Tenant-ID") String tenantId
@@ -25,6 +27,7 @@ public class PublisherController {
         return ResponseEntity.ok(svc.getAllPublishers());
     }
 
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/{id}")
     public ResponseEntity<PublisherDto> getPublisherById(
             @RequestHeader("X-Tenant-ID") String tenantId,
@@ -33,6 +36,7 @@ public class PublisherController {
         return ResponseEntity.ok(svc.getPublisherById(id));
     }
 
+    @PreAuthorize("hasAnyRole('LIBRARIAN','ADMIN')")
     @PostMapping
     public ResponseEntity<PublisherDto> createPublisher(
             @RequestHeader("X-Tenant-ID") String tenantId,
@@ -41,6 +45,7 @@ public class PublisherController {
         return ResponseEntity.ok(svc.createPublisher(dto));
     }
 
+    @PreAuthorize("hasAnyRole('LIBRARIAN','ADMIN')")
     @PutMapping("/{id}")
     public ResponseEntity<PublisherDto> updatePublisher(
             @RequestHeader("X-Tenant-ID") String tenantId,
@@ -50,6 +55,7 @@ public class PublisherController {
         return ResponseEntity.ok(svc.updatePublisher(id, dto));
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deletePublisher(
             @RequestHeader("X-Tenant-ID") String tenantId,

--- a/src/main/java/org/andi/librarymanagementbackend/controller/UserController.java
+++ b/src/main/java/org/andi/librarymanagementbackend/controller/UserController.java
@@ -3,6 +3,7 @@ package org.andi.librarymanagementbackend.controller;
 import org.andi.librarymanagementbackend.dto.UserDto;
 import org.andi.librarymanagementbackend.service.UserService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -18,28 +19,37 @@ public class UserController {
         this.userService = userService;
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping
     public ResponseEntity<List<UserDto>> getAllUsers() {
         return ResponseEntity.ok(userService.getAllUsers());
     }
 
+    @PreAuthorize("hasAnyRole('LIBRARIAN','ADMIN')")
     @GetMapping("/{id}")
-    public ResponseEntity<UserDto> getUserById(@PathVariable Long id) {
+    public ResponseEntity<UserDto> getUserById(@PathVariable Long id ,
+                                               @RequestHeader("X-Tenant-ID") String tenantId) {
         return ResponseEntity.ok(userService.getUserById(id));
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping
-    public ResponseEntity<UserDto> createUser(@RequestBody UserDto userDto) {
+    public ResponseEntity<UserDto> createUser(@RequestBody UserDto userDto,
+                                              @RequestHeader("X-Tenant-ID") String tenantId) {
         return ResponseEntity.ok(userService.createUser(userDto));
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @PutMapping("/{id}")
-    public ResponseEntity<UserDto> updateUser(@PathVariable Long id, @RequestBody UserDto userDto) {
+    public ResponseEntity<UserDto> updateUser(@PathVariable Long id,
+                                              @RequestBody UserDto userDto,
+                                              @RequestHeader("X-Tenant-ID") String tenantId) {
         return ResponseEntity.ok(userService.updateUser(id, userDto));
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
+    public ResponseEntity<Void> deleteUser(@PathVariable Long id,@RequestHeader("X-Tenant-ID") String tenantId) {
         userService.deleteUser(id);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/org/andi/librarymanagementbackend/dto/AuthResponseDto.java
+++ b/src/main/java/org/andi/librarymanagementbackend/dto/AuthResponseDto.java
@@ -1,0 +1,34 @@
+package org.andi.librarymanagementbackend.dto;
+
+public class AuthResponseDto {
+    private String token;
+    private String tokenType = "Bearer";
+    private Long userId;
+    private String fullName;
+    private String email;
+    private String role;
+
+    public AuthResponseDto() {}
+
+    public AuthResponseDto(String token, Long userId, String fullName, String email, String role) {
+        this.token = token;
+        this.userId = userId;
+        this.fullName = fullName;
+        this.email = email;
+        this.role = role;
+    }
+
+    // getters & setters
+    public String getToken() { return token; }
+    public void setToken(String token) { this.token = token; }
+    public String getTokenType() { return tokenType; }
+    public Long getUserId() { return userId; }
+    public void setUserId(Long userId) { this.userId = userId; }
+    public String getFullName() { return fullName; }
+    public void setFullName(String fullName) { this.fullName = fullName; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getRole() { return role; }
+    public void setRole(String role) { this.role = role; }
+}
+

--- a/src/main/java/org/andi/librarymanagementbackend/dto/LoginRequestDto.java
+++ b/src/main/java/org/andi/librarymanagementbackend/dto/LoginRequestDto.java
@@ -1,0 +1,20 @@
+package org.andi.librarymanagementbackend.dto;
+
+public class LoginRequestDto {
+    private String email;
+    private String password;
+
+    public LoginRequestDto() {}
+
+    public LoginRequestDto(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+
+    // getters & setters
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+}
+

--- a/src/main/java/org/andi/librarymanagementbackend/dto/RegisterRequestDto.java
+++ b/src/main/java/org/andi/librarymanagementbackend/dto/RegisterRequestDto.java
@@ -1,0 +1,24 @@
+package org.andi.librarymanagementbackend.dto;
+
+public class RegisterRequestDto {
+    private String fullName;
+    private String email;
+    private String password;
+
+    public RegisterRequestDto() {}
+
+    public RegisterRequestDto(String fullName, String email, String password) {
+        this.fullName = fullName;
+        this.email = email;
+        this.password = password;
+    }
+
+    // getters & setters
+    public String getFullName() { return fullName; }
+    public void setFullName(String fullName) { this.fullName = fullName; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+}
+

--- a/src/main/java/org/andi/librarymanagementbackend/repository/UserRepository.java
+++ b/src/main/java/org/andi/librarymanagementbackend/repository/UserRepository.java
@@ -3,8 +3,10 @@ package org.andi.librarymanagementbackend.repository;
 import org.andi.librarymanagementbackend.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
 }

--- a/src/main/java/org/andi/librarymanagementbackend/service/AuthService.java
+++ b/src/main/java/org/andi/librarymanagementbackend/service/AuthService.java
@@ -1,0 +1,10 @@
+package org.andi.librarymanagementbackend.service;
+
+import org.andi.librarymanagementbackend.dto.AuthResponseDto;
+import org.andi.librarymanagementbackend.dto.LoginRequestDto;
+import org.andi.librarymanagementbackend.dto.RegisterRequestDto;
+
+public interface AuthService {
+    AuthResponseDto register(RegisterRequestDto registerDto);
+    AuthResponseDto login(LoginRequestDto loginDto);
+}

--- a/src/main/java/org/andi/librarymanagementbackend/service/impl/AuthServiceImpl.java
+++ b/src/main/java/org/andi/librarymanagementbackend/service/impl/AuthServiceImpl.java
@@ -1,0 +1,55 @@
+package org.andi.librarymanagementbackend.service.impl;
+
+import org.andi.librarymanagementbackend.config.JwtUtil;
+import org.andi.librarymanagementbackend.dto.*;
+import org.andi.librarymanagementbackend.model.User;
+import org.andi.librarymanagementbackend.repository.UserRepository;
+import org.andi.librarymanagementbackend.service.AuthService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthServiceImpl implements AuthService {
+
+    private final UserRepository userRepo;
+    private final BCryptPasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    public AuthServiceImpl(UserRepository userRepo,
+                           BCryptPasswordEncoder passwordEncoder , JwtUtil jwtUtil ) {
+        this.userRepo = userRepo;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    public AuthResponseDto register(RegisterRequestDto dto) {
+        if (userRepo.existsByEmail(dto.getEmail())) {
+            throw new RuntimeException("Email already in use");
+        }
+        User user = new User(
+                dto.getFullName(),
+                dto.getEmail(),
+                passwordEncoder.encode(dto.getPassword()),
+                User.Role.MEMBER // default role
+        );
+        user = userRepo.save(user);
+        // generate token with jwtUtil
+        String token = jwtUtil.generateToken(user.getEmail());
+        return new AuthResponseDto(token, user.getId(),
+                user.getFullName(), user.getEmail(), user.getRole().name());
+    }
+
+    @Override
+    public AuthResponseDto login(LoginRequestDto dto) {
+        User user = userRepo.findByEmail(dto.getEmail())
+                .orElseThrow(() -> new RuntimeException("Invalid credentials"));
+        if (!passwordEncoder.matches(dto.getPassword(), user.getPassword())) {
+            throw new RuntimeException("Invalid credentials");
+        }
+        // generate token
+        String token = jwtUtil.generateToken(user.getEmail());
+        return new AuthResponseDto(token, user.getId(),
+                user.getFullName(), user.getEmail(), user.getRole().name());
+    }
+}

--- a/src/main/java/org/andi/librarymanagementbackend/service/impl/UserDetailsServiceImpl.java
+++ b/src/main/java/org/andi/librarymanagementbackend/service/impl/UserDetailsServiceImpl.java
@@ -1,0 +1,28 @@
+package org.andi.librarymanagementbackend.service.impl;
+
+import org.andi.librarymanagementbackend.model.User;
+import org.andi.librarymanagementbackend.repository.UserRepository;
+import org.springframework.security.core.userdetails.*;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository repo;
+
+    public UserDetailsServiceImpl(UserRepository repo) {
+        this.repo = repo;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = repo.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + email));
+        return org.springframework.security.core.userdetails.User
+                .withUsername(user.getEmail())
+                .password(user.getPassword())
+                .roles(user.getRole().name())
+                .build();
+
+    }
+}

--- a/src/main/java/org/andi/librarymanagementbackend/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/andi/librarymanagementbackend/service/impl/UserServiceImpl.java
@@ -1,4 +1,4 @@
-package org.andi.librarymanagementbackend.service;
+package org.andi.librarymanagementbackend.service.impl;
 
 import org.andi.librarymanagementbackend.dto.UserDto;
 import org.andi.librarymanagementbackend.mapper.UserMapper;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,6 +17,12 @@ spring.flyway.enabled=false
 spring.flyway.baseline-on-migrate=true
 spring.flyway.locations=classpath:db/migration
 
+# JWT configuration
+jwt.secret=MySuperSecretKey12345
+jwt.expirationMs=3600000
+
+
+
 spring.security.user.name=admin
 spring.security.user.password=admin
 


### PR DESCRIPTION
- Introduce JwtUtil that generates a secure HS512 key automatically.
- Configure SecurityConfig to disable HTTP Basic/form login and enforce stateless JWT filter.
- Update AuthController.register & .login to require X-Tenant-ID header, ensuring multi-tenancy filter no longer rejects preflight OPTIONS.
- Add global CORS policy to allow X-Tenant-ID, Authorization, and JSON.
- Verify register/login flows return AuthResponseDto with real tokens, and secured endpoints accept Bearer tokens for all roles.

This lays the foundation for secure, multi-tenant JWT-based auth across the API. All existing auth and user endpoints have been tested via Swagger UI and curl.